### PR TITLE
Add options "align" and "alt"

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -197,6 +197,8 @@ The **tikz-directive** can be used in two ways::
      across lines›
      :libs: ‹tikz libraries›
      :stringsubst:
+     :align: <left|center|right>
+     :alt: <alternative text>
 
 or::
 
@@ -204,6 +206,8 @@ or::
      across lines›
      :libs: ‹tikz libraries›
      :stringsubst:
+     :align: <left|center|right>
+     :alt: <alternative text>
 
      ‹tikz code, potentially broken
      across lines›
@@ -220,6 +224,10 @@ The ``:stringsubst:`` option enables the following string substitution in the
 ``‹tikz code›``:  Before processing the ``‹tikz code›`` the string ``$wd`` or
 ``$(wd)`` is replaced by the project root directory.  This is convenient when
 referring to some source file in the LaTeX code.
+
+The ``:align:`` option expects "left", "center", or "right" to specify the horizontal alignment of the image, equivalent to the HTML "text-align" CSS property. The default value is "center".
+
+The ``:alt:`` option specifies the alternative text, which is a short description of the image, displayed by applications that cannot display images, or spoken by applications for visually impaired users. The default value is "This is a figure."
 
 The ``‹tikz code›`` is code according to the Ti\ *k*\ Z LaTeX package.  It
 behaves as if inside a ``tikzpicture`` environment.  The presence of

--- a/sphinxcontrib/tikz.py
+++ b/sphinxcontrib/tikz.py
@@ -133,6 +133,8 @@ class TikzDirective(Directive):
     optional_arguments = 1
     final_argument_whitespace = True
     option_spec = {'libs': directives.unchanged,
+                   'alt': directives.unchanged,
+                   'align': directives.unchanged,
                    'stringsubst': directives.flag,
                    'include': directives.unchanged}
 
@@ -165,6 +167,8 @@ class TikzDirective(Directive):
                 captionstr = '\n'.join(self.arguments)
 
         node['libs'] = self.options.get('libs', '')
+        node['alt'] = self.options.get('alt', 'This is a figure.')
+        node['align'] = self.options.get('align', 'center')
         if 'stringsubst' in self.options:
             node['stringsubst'] = True
         else:
@@ -303,7 +307,7 @@ def html_visit_tikzinline(self, node):
         sm.walkabout(self)
     else:
         self.body.append('<img src="%s" alt="%s"/>' %
-                         (fname, self.encode(node['tikz']).strip()))
+                         (fname, self.encode(node['alt']).strip()))
     raise nodes.SkipNode
 
 
@@ -318,10 +322,10 @@ def html_visit_tikz(self, node):
                                   backrefs=[], source=node['tikz'])
         sm.walkabout(self)
     else:
-        self.body.append(self.starttag(node, 'div', CLASS='figure'))
+        self.body.append(self.starttag(node, 'div', CLASS='figure', STYLE='text-align: %s' % self.encode(node['align']).strip()))
         self.body.append('<p>')
         self.body.append('<img src="%s" alt="%s" /></p>\n' %
-                         (fname, self.encode(node['tikz']).strip()))
+                         (fname, self.encode(node['alt']).strip()))
 
 
 def html_depart_tikz(self, node):


### PR DESCRIPTION
The ``:align:`` option expects "left", "center", or "right" to specify the horizontal alignment of the image, equivalent to the HTML "text-align" CSS property. The default value is "center".

The ``:alt:`` option specifies the alternative text, which is a short description of the image, displayed by applications that cannot display images, or spoken by applications for visually impaired users. The default value is "This is a figure."