### PR TITLE
Implemented ``:xscale:`` option

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -195,14 +195,16 @@ The **tikz-directive** can be used in two ways::
 
   .. tikz:: ‹tikz code, potentially broken
      across lines›
-     :libs: ‹tikz libraries›
+     :libs:   ‹tikz libraries›
+     :xscale: ‹integer value between 0 and 100›
      :stringsubst:
 
 or::
 
   .. tikz:: ‹caption, potentially broken
      across lines›
-     :libs: ‹tikz libraries›
+     :libs:   ‹tikz libraries›
+     :xscale: ‹integer value between 0 and 100›
      :stringsubst:
 
      ‹tikz code, potentially broken
@@ -214,6 +216,14 @@ below the picture.
 The ``:libs:`` option expects its argument ``‹tikz libraries›`` to be a comma
 separated list of Ti\ *k*\ z libraries to use.  If you want to build the LaTeX
 target then make sure to add these libraries to the configuration value
+
+The ``:xscale:`` option expects its argument ``‹integer value between 0 and 100›``
+a percentage that determines the scaling factor relative to the content width.
+For the ``latex`` target, this is ``\columnwidth``, and for the ``html`` target,
+the percentage is added to the generated ``<\img>`` as a ``width`` attribute.
+The aspect ratio of the image is preserved.
+
+
 ``tikz_tikzlibraries`` in ``conf.py``.
 
 The ``:stringsubst:`` option enables the following string substitution in the
@@ -230,8 +240,9 @@ used to import the code from a file::
 
   .. tikz::‹caption, potentially broken
      across lines›
-     :libs: ‹tikz libraries›
+     :libs:    ‹tikz libraries›
      :include: ‹filename›
+     :xscale:  ‹integer value between 0 and 100›
      :stringsubst:
 
 The **tikz-role** is used as follows::


### PR DESCRIPTION
Hey there,

First of all: Many thanks for sharing such a great work! This extension is fantastic!

However, I faced the problem that some of my figures had an overhang in the generated PDF (because they were too big), so I found it quite handy to have an option to adjust the figure's width with regard to the available width in the target document. I didn't find such functionality, so I implemented it :)

I hope you find it useful as well! I think with ``:xscale:``, it is pretty easy to adjust the width in an intuitive manner. Would be cool to see that propagating to upstream, and eventually a new release on PiPy :)

Cheers,
Christian

Here is the essence:

* ``:xscale:`` expects an integer between 0 and 100, signifying a percentage to scale the image relative to the content width
* For the ``latex`` target, the content width is ``\columnwidth``
* For the ``html`` target, the ``width`` attribute of ``<img>`` is
  set to the percentage given in the option, which scales the image
  to the width of the surrounding container
* No input validation, the user is expected to know what she does
* The aspect ratio is preserved
* Successfully tested for ``latexpdf`` (single- and two-column) and
  ``html`` output
* Updated documentation (README)