### PR TITLE
[#10] add option to support include image in tikz

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -169,6 +169,11 @@ Additionally, the following configuration values are supported:
 
     tikz_tikzlibraries = ‹string›
 
+* Add path option for include image insert into tikz (see #10), when building html copy source/‹relative path› 
+  to tmp directory::
+
+    tikz_include_image = ‹relative path›
+
 .. note:: If you want to use the ``latex`` target, then you have to take care to
    include in ``tikz_libraries`` any ``‹tikz libraries›`` given to the ``libs``
    option of the ``tikz`` directive (see :ref:`usage`)

--- a/sphinxcontrib/tikz.py
+++ b/sphinxcontrib/tikz.py
@@ -430,6 +430,16 @@ def cleanup_tempdir(app, exc):
 def builder_inited(app):
     app.builder._tikz_tempdir = tempfile.mkdtemp()
 
+    src=app.srcdir+"/"+app.builder.config.tikz_include_image
+    desc=app.builder._tikz_tempdir+"/"+app.builder.config.tikz_include_image
+
+    if app.builder.config.tikz_include_image:
+        try:
+            shutil.copytree(src,desc)
+        except Exception:
+            pass
+
+
     if app.builder.name == "latex":
         sty_path = os.path.join(app.builder._tikz_tempdir,
                                 "sphinxcontribtikz.sty")
@@ -483,6 +493,7 @@ def setup(app):
     app.add_config_value('tikz_latex_preamble', '', 'html')
     app.add_config_value('tikz_tikzlibraries', '', 'html')
     app.add_config_value('tikz_transparent', True, 'html')
+    app.add_config_value('tikz_include_image', '', 'html')
 
     # fallback to another value depending what is on the system
     suite = 'pdf2svg'


### PR DESCRIPTION
changes: add option when building html copy source/‹relative path› to tikz tmp build directory
	
    modify：     sphinxcontrib/tikz.py

Signed-off-by: Zhang, Guodong <gdzhang@linx-info.com>