### PR TITLE
Fix #13: remove use_2to3 in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,11 +36,6 @@ if __name__ == "__main__":
     from setuptools import setup, find_packages
     import sys
 
-    # Use 2to3 for Python 3 without warnings in Python 2
-    extra = {}
-    if sys.version_info >= (3,):
-        extra['use_2to3'] = True
-
     setup(
         name=NAME,
         version=VERSION,
@@ -58,5 +53,4 @@ if __name__ == "__main__":
         include_package_data=True,
         install_requires=REQUIRES,
         namespace_packages=['sphinxcontrib'],
-        **extra
         )

--- a/setup.py
+++ b/setup.py
@@ -23,10 +23,11 @@ CLASSIFIERS  = [
     'License :: OSI Approved :: BSD License',
     'Operating System :: OS Independent',
     'Programming Language :: Python',
-    'Programming Language :: Python :: 2',
-    'Programming Language :: Python :: 2.7',
     'Programming Language :: Python :: 3',
-    'Programming Language :: Python :: 3.4',
+    'Programming Language :: Python :: 3.6'
+    'Programming Language :: Python :: 3.7'
+    'Programming Language :: Python :: 3.8'
+    'Programming Language :: Python :: 3.9'
     'Topic :: Documentation',
     'Topic :: Utilities',
     ]

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 # To perform those tests, install `tox` and run "tox" from this directory.
 
 [tox]
-envlist = py27, py34
+envlist = py36, py39
 
 [testenv]
 changedir=doc


### PR DESCRIPTION
This also changes the classifiers in setup.py to only claim to work with currently supported Python versions (3.6 to 3.9), and tests both 3.6 and 3.9 in tox.ini. Both versions pass the tests.