### PR TITLE
readme: add texlive-latex-extra dependency

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -49,7 +49,8 @@ Ubuntu Linux
 For **Ubuntu Linux** you roughly have to make sure that the following packages
 are installed:
 
-A. ``texlive`` and ``texlive-pictures`` (and maybe more LaTeX packages)
+A. ``texlive``, ``texlive-pictures``, and ``texlive-latex-extra`` (and maybe
+   more LaTeX packages)
 
 B. Depending on the chosen conversion suite the following package(s) have to be
    installed:


### PR DESCRIPTION
While using `sphinxcontrib.tikz`, I encountered an error similar to that documented in
https://github.com/JuliaTeX/TikzPictures.jl/issues/68, namely, that `standalone.cls` was not found. On Ubuntu Linux 22.04 (and probably earlier), this file is installed with the `texlive-latex-extra` package.

To help other users avoid this error, this pull request adds that package to the list of Ubuntu Linux package dependencies for
`sphinxcontrib.tikz` discussed in `README.rst`.

Installing this package also ensures that the `amsmath` LaTeX packages are installed. Those LaTeX packages are part of the `texlive-latex-base` package, which is a dependency of `texlive-latex-extra`.

Signed-off-by: Geoffrey M. Oxberry <geoffrey.oxberry@datadoghq.com>